### PR TITLE
Add IPData, Windows support, bugfixes

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -11,6 +11,10 @@ proxyAllowedIps = ["127.0.0.1"]
 qemuArgs = "qemu-system-x86_64"
 vncPort = 5900
 snapshots = true
+# Uncomment qmpHost and qmpPort if you're using Windows.
+#qmpHost = "127.0.0.1"
+#qmpPort = "5800"
+# Comment out qmpSockDir if you're using Windows.
 qmpSockDir = "/tmp/"
 
 [collabvm]
@@ -31,6 +35,8 @@ tempMuteTime = 30
 turnTime = 20
 # How long a reset vote lasts, in seconds
 voteTime = 100
+# How long until another vote can be started, in seconds
+voteCooldown = 180
 # SHA256 sum of the admin and mod passwords. This can be generated with the following command:
 # printf "<password>" | sha256sum -
 # Example hash is hunter2 and hunter3

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -9,7 +9,9 @@ export default interface IConfig {
         qemuArgs : string;
         vncPort : number;
         snapshots : boolean;
-        qmpSockDir : string;
+        qmpHost : string | null;
+        qmpPort : number | null;
+        qmpSockDir : string | null;
     };
     collabvm : {
         node : string;
@@ -27,6 +29,7 @@ export default interface IConfig {
         tempMuteTime : number;
         turnTime : number;
         voteTime : number;
+        voteCooldown: number;
         adminpass : string;
         modpass : string;
         moderatorPermissions : Permissions;

--- a/src/IPData.ts
+++ b/src/IPData.ts
@@ -1,0 +1,12 @@
+export class IPData {
+    tempMuteExpireTimeout? : NodeJS.Timer;
+    muted: Boolean;
+    vote: boolean | null;
+    address: string;
+
+    constructor(address: string) {
+        this.address = address;
+        this.muted = false;
+        this.vote = null;
+    }
+}

--- a/src/QMPClient.ts
+++ b/src/QMPClient.ts
@@ -4,12 +4,14 @@ import { Mutex } from "async-mutex";
 
 export default class QMPClient extends EventEmitter {
     socketfile : string;
+    sockettype: string;
     socket : Socket;
     connected : boolean;
     sentConnected : boolean;
     cmdMutex : Mutex; // So command outputs don't get mixed up
-    constructor(socketfile : string) {
+    constructor(socketfile : string, sockettype: string) {
         super();
+        this.sockettype = sockettype;
         this.socketfile = socketfile;
         this.socket = new Socket();
         this.connected = false;
@@ -20,7 +22,12 @@ export default class QMPClient extends EventEmitter {
         return new Promise((res, rej) => {
             if (this.connected) {res(); return;}
             try {
-                this.socket.connect(this.socketfile);
+                if(this.sockettype == "tcp:") {
+                    let _sock = this.socketfile.split(':');
+                    this.socket.connect(parseInt(_sock[1]), _sock[0]);
+                }else{
+                    this.socket.connect(this.socketfile);
+                }
             } catch (e) {
                 this.onClose();
             }

--- a/src/WSServer.ts
+++ b/src/WSServer.ts
@@ -35,9 +35,9 @@ export default class WSServer {
     // How much time is left on the vote
     private voteTime : number;
     // How much time until another reset vote can be cast
-    private voteTimeout : number;
+    private voteCooldown : number;
     // Interval to keep track
-    private voteTimeoutInterval? : NodeJS.Timer;
+    private voteCooldownInterval? : NodeJS.Timer;
     private ModPerms : number;  
     private VM : QEMUVM;
     constructor(config : IConfig, vm : QEMUVM) {
@@ -49,8 +49,8 @@ export default class WSServer {
         this.ips = [];
         this.Config = config;
         this.voteInProgress = false;
-        this.voteTime = this.Config.collabvm.voteCooldown;
-        this.voteTimeout = 0;
+        this.voteTime = 0;
+        this.voteCooldown = this.Config.collabvm.voteCooldown;
         this.ModPerms = Utilities.MakeModPerms(this.Config.collabvm.moderatorPermissions);
         this.server = http.createServer();
         this.socket = new WebSocketServer({noServer: true});
@@ -264,8 +264,8 @@ export default class WSServer {
                 switch (msgArr[1]) {
                     case "1":
                         if (!this.voteInProgress) {
-                            if (this.voteTimeout !== 0) {
-                                client.sendMsg(guacutils.encode("vote", "3", this.voteTimeout.toString()));
+                            if (this.voteCooldown !== 0) {
+                                client.sendMsg(guacutils.encode("vote", "3", this.voteCooldown.toString()));
                                 return;
                             }
                             this.startVote();
@@ -605,11 +605,11 @@ export default class WSServer {
         this.clients.forEach(c => {
             c.IP.vote = null;
         });
-        this.voteTimeout = this.Config.collabvm.voteCooldown;
-        this.voteTimeoutInterval = setInterval(() => {
-            this.voteTimeout--;
-            if (this.voteTimeout < 1)
-                clearInterval(this.voteTimeoutInterval);
+        this.voteCooldown = this.Config.collabvm.voteCooldown;
+        this.voteCooldownInterval = setInterval(() => {
+            this.voteCooldown--;
+            if (this.voteCooldown < 1)
+                clearInterval(this.voteCooldownInterval);
         }, 1000);
     }
 

--- a/src/WSServer.ts
+++ b/src/WSServer.ts
@@ -50,7 +50,7 @@ export default class WSServer {
         this.Config = config;
         this.voteInProgress = false;
         this.voteTime = 0;
-        this.voteCooldown = this.Config.collabvm.voteCooldown;
+        this.voteCooldown = 0;
         this.ModPerms = Utilities.MakeModPerms(this.Config.collabvm.moderatorPermissions);
         this.server = http.createServer();
         this.socket = new WebSocketServer({noServer: true});

--- a/src/WSServer.ts
+++ b/src/WSServer.ts
@@ -155,6 +155,7 @@ export default class WSServer {
     };
 
     private connectionClosed(user : User) {
+        if(user.IP.vote != null) user.IP.vote = null;
         this.clients.splice(this.clients.indexOf(user), 1);
         console.log(`[DISCONNECT] From ${user.IP.address}${user.username ? ` with username ${user.username}` : ""}`);
         if (!user.username) return;


### PR DESCRIPTION
Changes:
- Added IPData: mutes and votes are now tracked per-IP instead of per-user.
- Windows support: QMP over TCP can now be enabled in the config.
- Vote cooldown can now be specified in the config.
- Fixed bugs:
  - "Username is already taken" message appearing when it shouldn't
 
**Side note: this PR is targeted at the `production` branch as it introduces fixes to a bug actively being abused on the main CollabVM instance.**
***Test locally before merging!***