### PR TITLE
Turns 2.0

### DIFF
--- a/cvmts/src/CollabVMServer.ts
+++ b/cvmts/src/CollabVMServer.ts
@@ -687,8 +687,8 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 
 	onAdminIndefiniteTurn(user: User): void {
 		if (user.rank !== Rank.Admin) return;
-		this.turnController.bypassTurn(user);
 		this.turnController.pauseQueue();
+		this.turnController.bypassTurn(user);
 	}
 
 	async onAdminHideScreen(user: User, show: boolean) {
@@ -849,6 +849,13 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 
 	clearTurns() {
 		this.logger.info({event: "turn/clearing turn queue"});
+
+		// similar hack to the one in TurnController
+		// see there for why it is a hack
+		if(this.turnController.paused()) {
+			this.turnController.unpauseQueue();
+		}
+
 		this.turnController.clearTurns();
 	}
 

--- a/cvmts/src/CollabVMServer.ts
+++ b/cvmts/src/CollabVMServer.ts
@@ -20,6 +20,7 @@ import { BanManager } from './BanManager.js';
 import { TheAuditLog } from './AuditLog.js';
 import { IProtocolMessageHandler, ListEntry, ProtocolAddUser, ProtocolFlag, ProtocolRenameStatus, ProtocolUpgradeCapability } from './protocol/Protocol.js';
 import { TheProtocolManager } from './protocol/Manager.js';
+import { TurnController, TurnQueue } from './TurnController.js';
 
 // Instead of strange hacks we can just use nodejs provided
 // import.meta properties, which have existed since LTS if not before
@@ -46,13 +47,7 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 
 	private ChatHistory: CircularBuffer<ChatHistory>;
 
-	private TurnQueue: Queue<User>;
-
-	// Time remaining on the current turn
-	private TurnTime: number;
-
-	// Interval to keep track of the current turn time
-	private TurnInterval?: NodeJS.Timeout;
+	private turnController: TurnController;
 
 	// If a reset vote is in progress
 	private voteInProgress: boolean;
@@ -79,8 +74,6 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 	private screenHiddenImg: Buffer;
 	private screenHiddenThumb: Buffer;
 
-	// Indefinite turn
-	private indefiniteTurn: User | null;
 	private ModPerms: number;
 	private VM: VM;
 
@@ -101,8 +94,7 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 	constructor(config: IConfig, vm: VM, banmgr: BanManager, auth: AuthManager | null, geoipReader: ReaderModel | null) {
 		this.Config = config;
 		this.ChatHistory = new CircularBuffer<ChatHistory>(Array, this.Config.collabvm.maxChatHistoryLength);
-		this.TurnQueue = new Queue<User>();
-		this.TurnTime = 0;
+		this.turnController = new TurnController(config, this.onTurnUpdate.bind(this));
 		this.clients = [];
 		this.voteInProgress = false;
 		this.voteTime = 0;
@@ -112,7 +104,6 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 		this.screenHiddenImg = readFileSync(path.join(kCVMTSAssetsRoot, 'screenhidden.jpeg'));
 		this.screenHiddenThumb = readFileSync(path.join(kCVMTSAssetsRoot, 'screenhiddenthumb.jpeg'));
 
-		this.indefiniteTurn = null;
 		this.ModPerms = Utilities.MakeModPerms(this.Config.collabvm.moderatorPermissions);
 
 		// No size initially, since there usually won't be a display connected at all during initalization
@@ -210,18 +201,12 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 			this.sendVoteUpdate();
 		}
 
-		if (this.indefiniteTurn === user) this.indefiniteTurn = null;
-
 		this.clients.splice(clientIndex, 1);
 
 		user.logger.info({event: "user/disconnect"});
 		if (!user.username) return;
-		if (this.TurnQueue.toArray().indexOf(user) !== -1) {
-			var hadturn = this.TurnQueue.peek() === user;
-			this.TurnQueue = Queue.from(this.TurnQueue.toArray().filter((u) => u !== user));
-			if (hadturn) this.nextTurn();
-		}
 
+		this.turnController.removeUser(user);
 		this.clients.forEach((c) => c.sendRemUser([user.username!]));
 	}
 
@@ -345,29 +330,25 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 		}
 
 		if (forfeit == false) {
-			var currentQueue = this.TurnQueue.toArray();
-			// If the user is already in the turn queue, ignore the turn request.
-			if (currentQueue.indexOf(user) !== -1) return;
+			if(this.turnController.userInQueue(user)) return;
+
 			// If they're muted, also ignore the turn request.
 			// Send them the turn queue to prevent client glitches
 			if (user.IP.muted) return;
 			if (this.Config.collabvm.turnlimit.enabled) {
 				// Get the amount of users in the turn queue with the same IP as the user requesting a turn.
-				let turns = currentQueue.filter((otheruser) => otheruser.IP.address == user.IP.address);
 				// If it exceeds the limit set in the config, ignore the turn request.
-				if (turns.length + 1 > this.Config.collabvm.turnlimit.maximum) {
+				let sameIp = this.turnController.usersWithSameIpInQueue(user);
+				if (sameIp > this.Config.collabvm.turnlimit.maximum) {
 					user.logger.warn({event: "turn/ignoring request due to turn limit"});
 					return;
 				}
 			}
 			user.logger.info({event: "turn/entering queue"});
-			this.TurnQueue.enqueue(user);
-			if (this.TurnQueue.size === 1) this.nextTurn();
+			this.turnController.addUser(user);
 		} else {
-			// Not sure why this wasn't using this before
-			this.endTurn(user);
+			this.turnController.removeUser(user);
 		}
-		this.sendTurnUpdate();
 	}
 
 	onVote(user: User, choice: number): void {
@@ -476,7 +457,7 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 		user.sendSync(Date.now());
 
 		if (this.voteInProgress) this.sendVoteUpdate(user);
-		this.sendTurnUpdate(user);
+		this.sendTurnUpdate(this.turnController.getTurnInfo(), user);
 	}
 
 	async onConnect(user: User, node: string) {
@@ -532,13 +513,13 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 	}
 
 	onKey(user: User, keysym: number, pressed: boolean): void {
-		if (this.TurnQueue.peek() !== user && user.rank !== Rank.Admin) return;
+		if (!this.turnController.userIsActive(user) && user.rank !== Rank.Admin) return;
 		user.logger.info({event: "key", keysym, pressed});
 		this.VM.GetDisplay()?.KeyboardEvent(keysym, pressed);
 	}
 
 	onMouse(user: User, x: number, y: number, buttonMask: number): void {
-		if (this.TurnQueue.peek() !== user && user.rank !== Rank.Admin) return;
+		if (!this.turnController.userIsActive(user) && user.rank !== Rank.Admin) return;
 		this.VM.GetDisplay()?.MouseEvent(x, y, buttonMask);
 	}
 
@@ -706,9 +687,8 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 
 	onAdminIndefiniteTurn(user: User): void {
 		if (user.rank !== Rank.Admin) return;
-		this.indefiniteTurn = user;
-		this.TurnQueue = Queue.from([user, ...this.TurnQueue.toArray().filter((c) => c !== user)]);
-		this.sendTurnUpdate();
+		this.turnController.bypassTurn(user);
+		this.turnController.pauseQueue();
 	}
 
 	async onAdminHideScreen(user: User, show: boolean) {
@@ -839,81 +819,47 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 		return arr;
 	}
 
-	private sendTurnUpdate(client?: User) {
-		var turnQueueArr = this.TurnQueue.toArray();
-		var turntime: number;
-		if (this.indefiniteTurn === null) turntime = this.TurnTime * 1000;
-		else turntime = 9999999999;
-		var users: string[] = [];
-
-		this.TurnQueue.forEach((c) => users.push(c.username!));
-
-		var currentTurningUser = this.TurnQueue.peek();
-
-		if (client) {
-			client.sendTurnQueue(turntime, users);
+	private sendTurnUpdate(state: TurnQueue, client: User) {
+		if(state.length == 0) {
+			client.sendTurnQueue(0, []);
 			return;
 		}
 
-		this.clients
-			.filter((c) => c !== currentTurningUser && c.connectedToNode)
-			.forEach((c) => {
-				if (turnQueueArr.indexOf(c) !== -1) {
-					var time;
-					if (this.indefiniteTurn === null) time = this.TurnTime * 1000 + (turnQueueArr.indexOf(c) - 1) * this.Config.collabvm.turnTime * 1000;
-					else time = 9999999999;
-					c.sendTurnQueueWaiting(turntime, users, time);
-				} else {
-					c.sendTurnQueue(turntime, users);
-				}
-			});
-		if (currentTurningUser) {
-			currentTurningUser.logger.info({event: "turn/held"});
-			currentTurningUser.sendTurnQueue(turntime, users);
+		let users = state.map((v) => v.user.username);
+		if(this.turnController.userInQueue(client)) {
+			let entry = state[state.findIndex((v) => v.user === client)];
+			if(entry.waiting) {
+				client.sendTurnQueueWaiting(state[0].time, users, state[0].time + entry.waitingTime!);
+			} else {
+				client.sendTurnQueue(state[0].time, users);
+			}
+		} else {
+			client.sendTurnQueue(state[0].time, users);
 		}
 	}
 
-	private nextTurn() {
-		clearInterval(this.TurnInterval);
-		if (this.TurnQueue.size === 0) {
-		} else {
-			this.TurnTime = this.Config.collabvm.turnTime;
-			this.TurnInterval = setInterval(() => this.turnInterval(), 1000);
-		}
-		this.sendTurnUpdate();
+	private onTurnUpdate(state: TurnQueue) {
+		// broadcast new turn state
+		this.clients
+			.filter((c) => c.connectedToNode)
+			.forEach((c) => {
+				this.sendTurnUpdate(state, c);
+			});
 	}
 
 	clearTurns() {
 		this.logger.info({event: "turn/clearing turn queue"});
-		clearInterval(this.TurnInterval);
-		this.TurnQueue.clear();
-		this.sendTurnUpdate();
+		this.turnController.clearTurns();
 	}
 
 	bypassTurn(client: User) {
 		client.logger.info({event: "turn/bypassing"});
-		var a = this.TurnQueue.toArray().filter((c) => c !== client);
-		this.TurnQueue = Queue.from([client, ...a]);
-		this.nextTurn();
+		this.turnController.bypassTurn(client);
 	}
 
 	endTurn(client: User) {
 		client.logger.info({event: "turn/ending"});
-		// I must have somehow accidentally removed this while scalpaling everything out
-		if (this.indefiniteTurn === client) this.indefiniteTurn = null;
-		var hasTurn = this.TurnQueue.peek() === client;
-		this.TurnQueue = Queue.from(this.TurnQueue.toArray().filter((c) => c !== client));
-		if (hasTurn) this.nextTurn();
-		else this.sendTurnUpdate();
-	}
-
-	private turnInterval() {
-		if (this.indefiniteTurn !== null) return;
-		this.TurnTime--;
-		if (this.TurnTime < 1) {
-			this.TurnQueue.dequeue();
-			this.nextTurn();
-		}
+		this.turnController.removeUser(client);
 	}
 
 	private OnDisplayRectangle(rect: Rect) {

--- a/cvmts/src/CollabVMServer.ts
+++ b/cvmts/src/CollabVMServer.ts
@@ -65,7 +65,7 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 	private voteCooldownInterval?: NodeJS.Timeout;
 
 	// Completely disable turns
-	private turnsAllowed: boolean;
+	private votesAllowed: boolean;
 
 	// Hide the screen
 	private screenHidden: boolean;
@@ -99,7 +99,7 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 		this.voteInProgress = false;
 		this.voteTime = 0;
 		this.voteCooldown = 0;
-		this.turnsAllowed = true;
+		this.votesAllowed = true;
 		this.screenHidden = false;
 		this.screenHiddenImg = readFileSync(path.join(kCVMTSAssetsRoot, 'screenhidden.jpeg'));
 		this.screenHiddenThumb = readFileSync(path.join(kCVMTSAssetsRoot, 'screenhiddenthumb.jpeg'));
@@ -316,7 +316,7 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 
 	onTurnRequest(user: User, forfeit: boolean): void {
 		user.logger.trace({event: "turn/requested"});
-		if ((!this.turnsAllowed || this.Config.collabvm.turnwhitelist) && user.rank !== Rank.Admin && user.rank !== Rank.Moderator && !user.turnWhitelist) return;
+		if ((this.Config.collabvm.turnwhitelist) && user.rank !== Rank.Admin && user.rank !== Rank.Moderator && !user.turnWhitelist) return;
 
 		if (!this.authCheck(user, this.Config.auth.guestPermissions.turn)) return;
 
@@ -356,7 +356,7 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 			user.logger.warn({event: "vote/voted without snapshots enabled"});
 			return;
 		}
-		if ((!this.turnsAllowed || this.Config.collabvm.turnwhitelist) && user.rank !== Rank.Admin && user.rank !== Rank.Moderator && !user.turnWhitelist) return;
+		if ((!this.votesAllowed || this.Config.collabvm.turnwhitelist) && user.rank !== Rank.Admin && user.rank !== Rank.Moderator && !user.turnWhitelist) return;
 		if (!user.connectedToNode) {
 			user.logger.warn({event: "vote/not connected to node"});
 			return;
@@ -677,11 +677,11 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 
 	onAdminToggleTurns(user: User, enabled: boolean): void {
 		if (user.rank !== Rank.Admin) return;
+		this.votesAllowed = enabled;
 		if (enabled) {
-			this.turnsAllowed = true;
+			this.turnController.unpauseQueue();
 		} else {
-			this.turnsAllowed = false;
-			this.clearTurns();
+			this.turnController.pauseQueue();
 		}
 	}
 
@@ -825,9 +825,20 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 			return;
 		}
 
-		let users = state.map((v) => v.user.username);
+		let users = state
+			.map((v) => {
+				// this kinda fuckin sucks but what will you do.
+				if(v.user)
+					return v.user.username;
+				return '';
+			});
 		if(this.turnController.userInQueue(client)) {
-			let entry = state[state.findIndex((v) => v.user === client)];
+			let entry = state[state.findIndex((v) => {
+				if(v.user == null)
+					return false;
+				return v.user.username === client.username;
+			})];
+
 			if(entry.waiting) {
 				client.sendTurnQueueWaiting(state[0].time, users, state[0].time + entry.waitingTime!);
 			} else {
@@ -849,13 +860,6 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 
 	clearTurns() {
 		this.logger.info({event: "turn/clearing turn queue"});
-
-		// similar hack to the one in TurnController
-		// see there for why it is a hack
-		if(this.turnController.paused()) {
-			this.turnController.unpauseQueue();
-		}
-
 		this.turnController.clearTurns();
 	}
 

--- a/cvmts/src/CollabVMServer.ts
+++ b/cvmts/src/CollabVMServer.ts
@@ -20,7 +20,7 @@ import { BanManager } from './BanManager.js';
 import { TheAuditLog } from './AuditLog.js';
 import { IProtocolMessageHandler, ListEntry, ProtocolAddUser, ProtocolFlag, ProtocolRenameStatus, ProtocolUpgradeCapability } from './protocol/Protocol.js';
 import { TheProtocolManager } from './protocol/Manager.js';
-import { TurnController, TurnQueue } from './TurnController.js';
+import { SpecialTurnTimes, TurnController, TurnQueue } from './TurnController.js';
 
 // Instead of strange hacks we can just use nodejs provided
 // import.meta properties, which have existed since LTS if not before
@@ -821,17 +821,16 @@ export default class CollabVMServer implements IProtocolMessageHandler {
 
 	private sendTurnUpdate(state: TurnQueue, client: User) {
 		if(state.length == 0) {
-			client.sendTurnQueue(0, []);
+			// kinda not happy about this because it's a bit leaky, but it's better than before I suppose
+			if(this.turnController.paused())
+				client.sendTurnQueue(SpecialTurnTimes.Paused, []);
+			else
+				client.sendTurnQueue(0, []);
 			return;
 		}
 
 		let users = state
-			.map((v) => {
-				// this kinda fuckin sucks but what will you do.
-				if(v.user)
-					return v.user.username;
-				return '';
-			});
+			.map((v) => v.user.username);
 		if(this.turnController.userInQueue(client)) {
 			let entry = state[state.findIndex((v) => {
 				if(v.user == null)

--- a/cvmts/src/TurnController.ts
+++ b/cvmts/src/TurnController.ts
@@ -18,7 +18,7 @@ export enum SpecialTurnTimes {
 }
 
 export interface TurnQueueEntry {
-	user: User;
+	user?: User;
 	time: number; // time left
 
 	waiting: boolean;
@@ -93,8 +93,6 @@ export class TurnController {
 		}
 	}
 
-
-
 	private updateStateMachine() {
 		if(!this.paused()) {
 			// this is kind of ugly but basically this transitions into the correct
@@ -135,13 +133,6 @@ export class TurnController {
 			return;
 
 		if(this.queue.peek() == user) {
-			// bit of a "temporary" hack to unpause the queue from an infinite turn
-			// should probably add new admin ops to pause and unpause queue & do that instead...
-			// kinda nasty but whatever
-			if(this.paused()) {
-				this.unpauseQueue();
-			}
-
 			this.endCurrentTurn();
 			return;
 		} else {
@@ -172,8 +163,10 @@ export class TurnController {
 	}
 
 	pauseQueue() {
-		if(!this.paused())
+		if(!this.paused()) {
 			this.transitionToState(TurnState.Active_Paused);
+			this.updateStateMachine();
+		}
 	}
 
 	paused() { 
@@ -181,8 +174,10 @@ export class TurnController {
 	}
 
 	unpauseQueue() {
-		if(this.paused())
+		if(this.paused()) {
 			this.transitionToState(TurnState.Active);
+			this.updateStateMachine();
+		}
 	}
 
 	usersWithSameIpInQueue(user: User) {
@@ -209,7 +204,7 @@ export class TurnController {
 				let user = this.queue.peek()!;
 				return [ 
 					{
-						user,
+						user: user,
 						time: SpecialTurnTimes.OneUser,
 						waiting: false
 					}
@@ -231,7 +226,7 @@ export class TurnController {
 					if(user == currentTurningUser)
 						return;
 					users.push({
-						user,
+						user: user,
 						// position specific time
 						time: remainingTurnTimeMs,
 						waiting: true,
@@ -244,24 +239,31 @@ export class TurnController {
 
 			case TurnState.Active_Paused: {
 				let users: TurnQueueEntry[] = [];
-				let currentTurningUser = this.queue.peek()!;
-
-				users.push({
-					user: currentTurningUser,
-					time: SpecialTurnTimes.Paused,
-					waiting: false
-				});
-
-				this.queue.forEach((user: User, queueIndex: number) => {
-					if(user == currentTurningUser)
-						return;
+				if(this.queue.size == 0) {
 					users.push({
-						user,
 						time: SpecialTurnTimes.Paused,
-						waiting: true,
-						waitingTime: SpecialTurnTimes.Paused,
+						waiting: false
 					});
-				});
+				} else {
+					let currentTurningUser = this.queue.peek()!;
+
+					users.push({
+						user: currentTurningUser,
+						time: SpecialTurnTimes.Paused,
+						waiting: false
+					});
+
+					this.queue.forEach((user: User, queueIndex: number) => {
+						if(user == currentTurningUser)
+							return;
+						users.push({
+							user: user,
+							time: SpecialTurnTimes.Paused,
+							waiting: true,
+							waitingTime: SpecialTurnTimes.Paused,
+						});
+					});
+				}
 
 				return users;
 			};

--- a/cvmts/src/TurnController.ts
+++ b/cvmts/src/TurnController.ts
@@ -1,0 +1,275 @@
+import Queue from 'mnemonist/queue.js';
+import * as Utilities from './Utilities.js';
+import { User, Rank } from './User.js';
+import IConfig from './IConfig.js';
+import { Timer } from './util/timer.js';
+
+export enum TurnState {
+	Inactive = 0, // default state, no one is turning
+
+	Active, // turn queue is active. can only go to Active_OneUser or Inactive states
+	Active_OneUser, // active, but paused because only one user is active
+	Active_Paused, // active, but explicitly paused by an admin or moderator
+}
+
+// TODO only OneUser is used atm
+export enum SpecialTurnTimes {
+	OneUser = 2147483647,
+	Paused = 2147483646,
+	IndefiniteTurn = 2147483645
+}
+
+export interface TurnQueueEntry {
+	user: User;
+	time: number; // time left
+
+	waiting: boolean;
+	waitingTime?: number; // set if waiting == true
+}
+
+export type TurnQueue = TurnQueueEntry[];
+
+export class TurnController {
+	private queue: Queue<User>;
+	private state: TurnState = TurnState.Inactive;
+	private turnTimer: Timer;
+	private updateCb: (state: TurnQueue) => void;
+
+	constructor(config: IConfig, updateCb: (state: TurnQueue)=>void) {
+		this.queue = new Queue();
+		this.turnTimer = new Timer(config.collabvm.turnTime, this.onTurnTimerElapsed.bind(this));
+		this.updateCb = updateCb;
+	}
+
+	private transitionToState(newState: TurnState) {
+		if(this.state !== newState) {
+			let fromState = this.state;
+			this.state = newState;
+			this.onTurnStateChange(fromState);
+		}
+	}
+
+	private onTurnStateChange(fromState: TurnState) {
+		switch(this.state) {
+			case TurnState.Inactive: {
+				if(fromState == TurnState.Active || fromState == TurnState.Active_OneUser) {
+					// disarm the timer
+					this.turnTimer.disarm();
+				}
+			};
+
+			case TurnState.Active_OneUser: {
+				// We can transition into this state from Active.
+				if(fromState == TurnState.Active) {
+					if(this.turnTimer.wasArmed())
+						this.turnTimer.pause();
+				}
+			} break;
+
+			case TurnState.Active: {
+				// We can only enter here via Active_OneUser
+				// and Active_Paused states.
+
+				// arm or unpause the turn timer depending on what state we entrered from
+				if(fromState == TurnState.Active_Paused && this.turnTimer.wasArmed())
+					this.turnTimer.unpause();
+				else {
+					// re-arm the timer
+					this.turnTimer.arm();
+				}
+			} break;
+
+			case TurnState.Active_Paused: {
+				// this state can be entered by a user 
+				if(fromState !== TurnState.Inactive) {
+					if(this.turnTimer.wasArmed())
+						this.turnTimer.pause();
+				}
+			} break;
+		}
+	}
+
+	private onTurnTimerElapsed() {
+		this.queue.dequeue();
+		this.updateStateMachine();
+	}
+
+	private updateStateMachine() {
+		if(!this.paused()) {
+			// this is kind of ugly but basically this transitions into the correct
+			// state depending on the queue. 
+			if(this.queue.size > 1) {
+				this.transitionToState(TurnState.Active);
+			} else if(this.queue.size == 1) {
+				this.transitionToState(TurnState.Active_OneUser);
+			} else if(this.queue.size == 0) {
+				this.transitionToState(TurnState.Inactive);
+			}
+		}
+
+		// tell upstream layer about turn queue update
+		this.updateCb(this.getTurnInfo());
+	}
+
+
+	userInQueue(user: User) {
+		return Utilities.iteratorHasItem(this.queue.values(), user);
+	}
+
+	addUser(user: User) {
+		if(this.userInQueue(user))
+			return;
+
+		// Disallow entering the queue when it's paused
+		if(this.state == TurnState.Active_Paused)
+			return;
+
+		this.queue.enqueue(user);
+		this.updateStateMachine();
+	}
+
+	removeUser(user: User) {
+		// you jerkass
+		if(!this.userInQueue(user))
+			return;
+
+		if(this.queue.peek() == user) {
+			// kinda nasty but whatever
+			if(this.paused()) {
+				console.log('unpausing queue since indef turn is being removed')
+				this.unpauseQueue();
+			}
+
+			this.endCurrentTurn();
+			return;
+		} else {
+			if(this.paused())
+				return;
+
+			// bad!!!!! but this should hopefully be one of the last times we need to do this!
+			// other case is bypass turn
+			this.queue = Queue.from(this.queue.toArray().filter((c) => c !== user));
+		}
+
+		this.updateStateMachine();
+	}
+
+	bypassTurn(user: User) {
+		this.queue = Queue.from([user, ...this.queue.toArray().filter((c) => c !== user)]);
+		this.updateStateMachine();
+	}
+
+	endCurrentTurn() {
+		this.queue.dequeue();
+		this.updateStateMachine();
+	}
+
+	clearTurns() {
+		this.queue.clear();
+		this.updateStateMachine();
+	}
+
+	pauseQueue() {
+		this.transitionToState(TurnState.Active_Paused);
+	}
+
+	paused() { 
+		return this.state == TurnState.Active_Paused;
+	}
+
+	unpauseQueue() {
+		this.transitionToState(TurnState.Active);
+	}
+
+	usersWithSameIpInQueue(user: User) {
+		// better than the old way even though it's a bit verbose since this
+		// doesn't new a whole brand new array each time it's called :)
+		let count = 0;
+		this.queue.forEach((iteratedUser: User) => {
+			if(iteratedUser.IP.address == user.IP.address)
+				count++;
+		});
+		return count;
+	}
+
+
+	userIsActive(user: User) {
+		if(this.state == TurnState.Inactive)
+			return false;
+		return this.queue.peek() === user;
+	}
+
+	getTurnInfo() : TurnQueue {
+		switch(this.state) {
+			case TurnState.Active_OneUser: {
+				let user = this.queue.peek()!;
+				return [ 
+					{
+						user,
+						time: SpecialTurnTimes.OneUser,
+						waiting: false
+					}
+				];
+			};
+
+			// TODO it should be possible to merge these cases. hopefully not in too ugly of a way
+			// the least ugly way would probably involve ternary and some if soup though which i kind of don't like....
+
+			case TurnState.Active: {
+				let remainingTurnTimeMs = this.turnTimer.getRemaining() * 1000;
+				let users: TurnQueueEntry[] = [];
+				let currentTurningUser = this.queue.peek()!;
+
+				users.push({
+					user: currentTurningUser,
+					time: remainingTurnTimeMs,
+					waiting: false
+				});
+
+				this.queue.forEach((user: User, queueIndex: number) => {
+					if(user == currentTurningUser)
+						return;
+					users.push({
+						user,
+						// position specific time
+						time: remainingTurnTimeMs,
+						waiting: true,
+						waitingTime: (queueIndex-1) * (this.turnTimer.getInterval() * 1000),
+					});
+				});
+
+				return users;
+			};
+
+			case TurnState.Active_Paused: {
+				let users: TurnQueueEntry[] = [];
+				let currentTurningUser = this.queue.peek()!;
+
+				users.push({
+					user: currentTurningUser,
+					time: SpecialTurnTimes.OneUser,
+					waiting: false
+				});
+
+				this.queue.forEach((user: User, queueIndex: number) => {
+					if(user == currentTurningUser)
+						return;
+					users.push({
+						user,
+						time: SpecialTurnTimes.OneUser,
+						waiting: true,
+						waitingTime: SpecialTurnTimes.OneUser,
+					});
+				});
+
+				return users;
+			};
+
+			// In this case we can assume no one is in the list.
+			case TurnState.Inactive:
+			default:
+				return [];
+		}
+	}
+
+};

--- a/cvmts/src/TurnController.ts
+++ b/cvmts/src/TurnController.ts
@@ -18,7 +18,7 @@ export enum SpecialTurnTimes {
 }
 
 export interface TurnQueueEntry {
-	user?: User;
+	user: User;
 	time: number; // time left
 
 	waiting: boolean;
@@ -240,10 +240,7 @@ export class TurnController {
 			case TurnState.Active_Paused: {
 				let users: TurnQueueEntry[] = [];
 				if(this.queue.size == 0) {
-					users.push({
-						time: SpecialTurnTimes.Paused,
-						waiting: false
-					});
+					return users;
 				} else {
 					let currentTurningUser = this.queue.peek()!;
 

--- a/cvmts/src/TurnController.ts
+++ b/cvmts/src/TurnController.ts
@@ -1,6 +1,6 @@
 import Queue from 'mnemonist/queue.js';
 import * as Utilities from './Utilities.js';
-import { User, Rank } from './User.js';
+import { User } from './User.js';
 import IConfig from './IConfig.js';
 import { Timer } from './util/timer.js';
 
@@ -12,11 +12,9 @@ export enum TurnState {
 	Active_Paused, // active, but explicitly paused by an admin or moderator
 }
 
-// TODO only OneUser is used atm
 export enum SpecialTurnTimes {
 	OneUser = 2147483647,
-	Paused = 2147483646,
-	IndefiniteTurn = 2147483645
+	Paused = 2147483646
 }
 
 export interface TurnQueueEntry {
@@ -35,10 +33,15 @@ export class TurnController {
 	private turnTimer: Timer;
 	private updateCb: (state: TurnQueue) => void;
 
-	constructor(config: IConfig, updateCb: (state: TurnQueue)=>void) {
+	constructor(config: IConfig, updateCb: (state: TurnQueue) => void) {
 		this.queue = new Queue();
 		this.turnTimer = new Timer(config.collabvm.turnTime, this.onTurnTimerElapsed.bind(this));
 		this.updateCb = updateCb;
+	}
+
+	private onTurnTimerElapsed() {
+		this.queue.dequeue();
+		this.updateStateMachine();
 	}
 
 	private transitionToState(newState: TurnState) {
@@ -89,10 +92,7 @@ export class TurnController {
 		}
 	}
 
-	private onTurnTimerElapsed() {
-		this.queue.dequeue();
-		this.updateStateMachine();
-	}
+
 
 	private updateStateMachine() {
 		if(!this.paused()) {
@@ -105,10 +105,10 @@ export class TurnController {
 			} else if(this.queue.size == 0) {
 				this.transitionToState(TurnState.Inactive);
 			}
-		}
 
-		// tell upstream layer about turn queue update
-		this.updateCb(this.getTurnInfo());
+			// tell upstream layer about turn queue update
+			this.updateCb(this.getTurnInfo());
+		}
 	}
 
 
@@ -134,9 +134,10 @@ export class TurnController {
 			return;
 
 		if(this.queue.peek() == user) {
+			// bit of a "temporary" hack to unpause the queue from an infinite turn
+			// should probably add new admin ops to pause and unpause queue & do that instead...
 			// kinda nasty but whatever
 			if(this.paused()) {
-				console.log('unpausing queue since indef turn is being removed')
 				this.unpauseQueue();
 			}
 
@@ -170,7 +171,8 @@ export class TurnController {
 	}
 
 	pauseQueue() {
-		this.transitionToState(TurnState.Active_Paused);
+		if(!this.paused())
+			this.transitionToState(TurnState.Active_Paused);
 	}
 
 	paused() { 
@@ -178,7 +180,8 @@ export class TurnController {
 	}
 
 	unpauseQueue() {
-		this.transitionToState(TurnState.Active);
+		if(this.paused())
+			this.transitionToState(TurnState.Active);
 	}
 
 	usersWithSameIpInQueue(user: User) {
@@ -212,9 +215,6 @@ export class TurnController {
 				];
 			};
 
-			// TODO it should be possible to merge these cases. hopefully not in too ugly of a way
-			// the least ugly way would probably involve ternary and some if soup though which i kind of don't like....
-
 			case TurnState.Active: {
 				let remainingTurnTimeMs = this.turnTimer.getRemaining() * 1000;
 				let users: TurnQueueEntry[] = [];
@@ -247,7 +247,7 @@ export class TurnController {
 
 				users.push({
 					user: currentTurningUser,
-					time: SpecialTurnTimes.OneUser,
+					time: SpecialTurnTimes.Paused,
 					waiting: false
 				});
 
@@ -256,9 +256,9 @@ export class TurnController {
 						return;
 					users.push({
 						user,
-						time: SpecialTurnTimes.OneUser,
+						time: SpecialTurnTimes.Paused,
 						waiting: true,
-						waitingTime: SpecialTurnTimes.OneUser,
+						waitingTime: SpecialTurnTimes.Paused,
 					});
 				});
 

--- a/cvmts/src/TurnController.ts
+++ b/cvmts/src/TurnController.ts
@@ -83,7 +83,8 @@ export class TurnController {
 			} break;
 
 			case TurnState.Active_Paused: {
-				// this state can be entered by a user 
+				// We don't need to pause the turn timer if it was never armed or we entered
+				// from an inactive queue.
 				if(fromState !== TurnState.Inactive) {
 					if(this.turnTimer.wasArmed())
 						this.turnTimer.pause();
@@ -105,10 +106,10 @@ export class TurnController {
 			} else if(this.queue.size == 0) {
 				this.transitionToState(TurnState.Inactive);
 			}
-
-			// tell upstream layer about turn queue update
-			this.updateCb(this.getTurnInfo());
 		}
+
+		// tell upstream layer about turn queue update
+		this.updateCb(this.getTurnInfo());
 	}
 
 

--- a/cvmts/src/Utilities.ts
+++ b/cvmts/src/Utilities.ts
@@ -68,3 +68,14 @@ export function MakeModPerms(modperms: Permissions): number {
 	if (modperms.xss) perms |= 512;
 	return perms;
 }
+
+/// Returns true if iterating through the provided iterable produces the provided value.
+export function iteratorHasItem<T>(iter: Iterator<T>, expected: T) {
+	while(true) {
+		const { value, done } = iter.next();
+		if(done)
+			return false;
+		if(value == expected)
+			return true;
+	}
+}

--- a/cvmts/src/util/timer.ts
+++ b/cvmts/src/util/timer.ts
@@ -65,8 +65,6 @@ export class Timer {
 	}
 
 	getRemaining() {
-		//if(!this.wasArmed())
-		// throw new Error('Only makes sense to call Timer#getRemaning() when timer is armed');
 		return this.leftSeconds;
 	}
 

--- a/cvmts/src/util/timer.ts
+++ b/cvmts/src/util/timer.ts
@@ -1,0 +1,76 @@
+export class Timer {
+	private leftSeconds: number;
+	private timerInterval?: NodeJS.Timeout;
+	private intervalSeconds: number;
+	private onElapsedCb : () => void;
+
+	constructor(intervalSeconds: number, onElapsed: () => void) {
+		this.leftSeconds = 0;
+		this.intervalSeconds = intervalSeconds;
+		this.onElapsedCb = onElapsed;
+	}
+
+	private removeInterval() {
+		if(this.timerInterval) {
+			clearInterval(this.timerInterval);
+			this.timerInterval = undefined;
+		}
+	}
+
+	private addInterval() {
+		if(this.timerInterval)
+			this.removeInterval();
+		this.timerInterval = setInterval(this.onSecondElapsed.bind(this), 1000);
+	}
+
+	private onTimerElapsed() {
+		this.removeInterval();
+
+		// call user-provided handler
+		this.onElapsedCb();
+	}
+
+	private onSecondElapsed() {
+		this.leftSeconds--;
+		if (this.leftSeconds < 1) { 
+			this.onTimerElapsed();
+			return;
+		}
+	}
+
+	arm() {
+		// kick off the timer
+		this.leftSeconds = this.intervalSeconds;
+		this.addInterval();
+	}
+
+	disarm() {
+		this.removeInterval();
+		this.leftSeconds = 0;
+	}
+
+	pause() {
+		// remove interval, but don't reset the time left
+		// effectively this pauses the timer.
+		this.removeInterval();
+	}
+
+	wasArmed() {
+		return this.leftSeconds !== 0;
+	}
+
+	unpause() {
+		if(this.wasArmed())
+			this.addInterval();
+	}
+
+	getRemaining() {
+		//if(!this.wasArmed())
+		// throw new Error('Only makes sense to call Timer#getRemaning() when timer is armed');
+		return this.leftSeconds;
+	}
+
+	getInterval() {
+		return this.intervalSeconds;
+	}
+}


### PR DESCRIPTION
Yeah, the name is a little tongue in cheek. However, this PR implements a brand-new turn controller which has a number of fun features that have been requested for a while (well, about half a decade w/ change is a while, right?).

- **Possibly most important of all**: When a single user has the turn, their turn will last forever. Only when another person joins the queue does the turn timer actually start.
- Administrators can now pause and unpause the turn queue at will. This serves as a defacto replacement for the "infinite turn" admin op, which is still handled, but I'd imagine has been superceded by this.

I've taken some care to make sure this should allow other WIP things like audio to not merge conflict too horribly, but I can't guarantee that.

This is also entirely backwards compatible protocol wise (not that I'm happy about how I did that, but it works), though clients that aren't updated for this may act somewhat strange.
I'll be opening a companion webapp PR for support there.